### PR TITLE
small fixes needed for more recent GHCs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # exotic-list-monad changelog
 
+## v1.2.1
+
+- Add `UndecidableInstances` extension to `Control.Monad.List.NonEmpty.Exotic` to
+  deal with the `2 <= n + k` constraint in the `AlphaNOmegaK` monad on newer GHCs
+
+- Turn off the `x-partial` warning
+
 ## v1.2.0
 
 - Add the `AlphaNOmegaK` monad

--- a/exotic-list-monads.cabal
+++ b/exotic-list-monads.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           exotic-list-monads
-version:        1.2.0
+version:        1.2.1
 synopsis:       Non-standard monads on lists and non-empty lists
 description:    The usual list monad is only one of infinitely many ways to turn the list functor into a monad. The same applies to the usual non-empty list monad and the non-empty list functor. This library collects such non-standard "list" and "non-empty list" monads.
 category:       List, Monads
@@ -18,7 +18,7 @@ license:        MIT
 license-file:   LICENSE
 build-type:     Simple
 tested-with:
-    GHC ==9.4.8
+    GHC ==9.8.4
 extra-source-files:
     README.md
     CHANGELOG.md
@@ -36,7 +36,7 @@ library
       Paths_exotic_list_monads
   hs-source-dirs:
       src
-  ghc-options: -Wall -Wno-name-shadowing -fno-warn-partial-type-signatures
+  ghc-options: -Wall -Wno-name-shadowing -Wno-x-partial -fno-warn-partial-type-signatures
   build-depends:
       base >=4.9 && <5
   default-language: Haskell2010
@@ -50,7 +50,7 @@ test-suite spec
       Paths_exotic_list_monads
   hs-source-dirs:
       test
-  ghc-options: -Wall -Wno-name-shadowing -fno-warn-partial-type-signatures
+  ghc-options: -Wall -Wno-name-shadowing -Wno-x-partial -fno-warn-partial-type-signatures
   build-depends:
       QuickCheck
     , base >=4.9 && <5

--- a/package.yaml
+++ b/package.yaml
@@ -1,7 +1,7 @@
 name:        exotic-list-monads
 synopsis:    Non-standard monads on lists and non-empty lists
 description: The usual list monad is only one of infinitely many ways to turn the list functor into a monad. The same applies to the usual non-empty list monad and the non-empty list functor. This library collects such non-standard "list" and "non-empty list" monads.
-version:     1.2.0
+version:     1.2.1
 license:     MIT
 copyright:   (c) 2020-2025 Dylan McDermott, Maciej Piróg, Tarmo Uustalu
 author:      Maciej Piróg <maciej.adam.pirog@gmial.com>
@@ -19,12 +19,13 @@ extra-source-files:
 ghc-options:
  -Wall
  -Wno-name-shadowing
+ -Wno-x-partial
  -fno-warn-partial-type-signatures
 
 dependencies:
  - base >= 4.9 && < 5
 
-tested-with: GHC ==9.4.8
+tested-with: GHC ==9.8.4
 
 library:
   source-dirs: src

--- a/src/Control/Monad/List/Exotic.hs
+++ b/src/Control/Monad/List/Exotic.hs
@@ -7,7 +7,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE ViewPatterns #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
+-- {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE PolyKinds #-}
@@ -26,7 +26,7 @@
 -- |
 -- Module      : Control.Monad.List.Exotic
 -- Description : Non-standard monads on the list functor
--- Copyright   : (c) Dylan McDermott, Maciej Piróg, Tarmo Uustalu, 2020
+-- Copyright   : (c) 2020-2025 Dylan McDermott, Maciej Piróg, Tarmo Uustalu
 -- License     : MIT
 -- Maintainer  : maciej.adam.pirog@gmail.com
 -- Stability   : experimental
@@ -377,7 +377,7 @@ instance IsList (GlobalFailure a) where
 instance ListMonad GlobalFailure
 
 instance PointedMagma (GlobalFailure a) where
-  m <> t = join $ GlobalFailure $ [m, t]
+  m <> t = join $ GlobalFailure [m, t]
   eps    = GlobalFailure []
 
 instance ZeroSemigroup (GlobalFailure a)
@@ -473,7 +473,7 @@ instance IsList (MazeWalk a) where
 instance ListMonad MazeWalk
 
 instance PointedMagma (MazeWalk a) where
-  m <> t = join $ MazeWalk $ [m, t]
+  m <> t = join $ MazeWalk [m, t]
   eps    = MazeWalk []
 
 instance PalindromeAlgebra (MazeWalk a)
@@ -543,7 +543,7 @@ instance IsList (DiscreteHybrid a) where
 instance ListMonad DiscreteHybrid
 
 instance PointedMagma (DiscreteHybrid a) where
-  m <> t = join $ DiscreteHybrid $ [m, t]
+  m <> t = join $ DiscreteHybrid [m, t]
   eps    = DiscreteHybrid []
 
 instance LeaningAlgebra (DiscreteHybrid a)
@@ -614,7 +614,7 @@ instance IsList (ListUnfold a) where
 instance ListMonad ListUnfold
 
 instance PointedMagma (ListUnfold a) where
-  m <> t = join $ ListUnfold $ [m, t]
+  m <> t = join $ ListUnfold [m, t]
   eps    = ListUnfold []
 
 instance SkewedAlgebra (ListUnfold a)
@@ -703,7 +703,7 @@ instance (KnownNat n) => IsList (Stutter n a) where
 instance (KnownNat n) => ListMonad (Stutter n) 
 
 instance (KnownNat n) => PointedMagma (Stutter n a) where
-  m <> t = join $ Stutter $ [m, t]
+  m <> t = join $ Stutter [m, t]
   eps    = Stutter []
 
 instance (KnownNat n) => StutterAlgebra n (Stutter n a)
@@ -778,7 +778,7 @@ instance (KnownNat n) => IsList (StutterKeeper n a) where
 instance (KnownNat n) => ListMonad (StutterKeeper n) 
 
 instance (KnownNat n) => PointedMagma (StutterKeeper n a) where
-  m <> t = join $ StutterKeeper $ [m, t]
+  m <> t = join $ StutterKeeper [m, t]
   eps    = StutterKeeper []
 
 instance (KnownNat n) => StutterKeeperAlgebra n (StutterKeeper n a)
@@ -859,7 +859,7 @@ instance (KnownNat n, KnownNat m) => IsList (StutterStutter n m a) where
 instance (KnownNat n, KnownNat m) => ListMonad (StutterStutter n m) 
 
 instance (KnownNat n, KnownNat m) => PointedMagma (StutterStutter n m a) where
-  m <> t = join $ StutterStutter $ [m, t]
+  m <> t = join $ StutterStutter [m, t]
   eps    = StutterStutter []
 
 instance (KnownNat n, KnownNat m)

--- a/src/Control/Monad/List/NonEmpty/Exotic.hs
+++ b/src/Control/Monad/List/NonEmpty/Exotic.hs
@@ -2,12 +2,10 @@
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE ViewPatterns #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE PolyKinds #-}
@@ -15,14 +13,14 @@
 {-# LANGUAGE PartialTypeSignatures #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE OverloadedLists #-}
-
+{-# LANGUAGE UndecidableInstances #-} -- needed for the 2 < n + k constraint in AlphaNOmegaK
 
 -- {-# LANGUAGE OverloadedStrings #-}
 
 -- |
 -- Module      : Control.Monad.List.NonEmpty.Exotic
 -- Description : Non-standard monads on the non-empty list functor
--- Copyright   : (c) Dylan McDermott, Maciej Piróg, Tarmo Uustalu, 2020
+-- Copyright   : (c) 2020-2025 Dylan McDermott, Maciej Piróg, Tarmo Uustalu
 -- License     : MIT
 -- Maintainer  : maciej.adam.pirog@gmail.com
 -- Stability   : experimental
@@ -327,7 +325,7 @@ newtype Keeper a = Keeper { unKeeper :: NonEmpty a }
  deriving (Functor, Show, Eq)
 
 instance Applicative Keeper where
-  pure a = Keeper $ [a]  -- OverloadedLists
+  pure a = Keeper [a]  -- OverloadedLists
   (<*>)  = ap
 
 instance Monad Keeper where
@@ -346,7 +344,7 @@ instance IsNonEmpty (Keeper a) where
 instance NonEmptyMonad Keeper
 
 instance Magma (Keeper a) where
-  m <> t = join $ Keeper $ [m, t]
+  m <> t = join $ Keeper [m, t]
 
 instance XY (Keeper a)
 
@@ -387,7 +385,7 @@ newtype DiscreteHybridNE a =
  deriving (Functor, Show, Eq)
 
 instance Applicative DiscreteHybridNE where
-  pure a = DiscreteHybridNE $ [a]  -- OverloadedLists
+  pure a = DiscreteHybridNE [a]  -- OverloadedLists
   (<*>)  = ap
 
 instance Monad DiscreteHybridNE where
@@ -404,7 +402,7 @@ instance IsNonEmpty (DiscreteHybridNE a) where
 instance NonEmptyMonad DiscreteHybridNE
 
 instance Magma (DiscreteHybridNE a) where
-  m <> t = join $ DiscreteHybridNE $ [m, t]
+  m <> t = join $ DiscreteHybridNE [m, t]
 
 instance YZ (DiscreteHybridNE a)
 
@@ -445,7 +443,7 @@ newtype OpDiscreteHybridNE a =
  deriving (Functor, Show, Eq)
 
 instance Applicative OpDiscreteHybridNE where
-  pure a = OpDiscreteHybridNE $ [a]  -- OverloadedLists
+  pure a = OpDiscreteHybridNE [a]  -- OverloadedLists
   (<*>)  = ap
 
 instance Monad OpDiscreteHybridNE where
@@ -462,7 +460,7 @@ instance IsNonEmpty (OpDiscreteHybridNE a) where
 instance NonEmptyMonad OpDiscreteHybridNE
 
 instance Magma (OpDiscreteHybridNE a) where
-  m <> t = join $ OpDiscreteHybridNE $ [m, t]
+  m <> t = join $ OpDiscreteHybridNE [m, t]
 
 instance XZ (OpDiscreteHybridNE a)
 
@@ -504,7 +502,7 @@ newtype MazeWalkNE a =
  deriving (Functor, Show, Eq)
 
 instance Applicative MazeWalkNE where
-  pure a = MazeWalkNE $ [a]  -- OverloadedLists
+  pure a = MazeWalkNE [a]  -- OverloadedLists
   (<*>)  = ap
 
 instance Monad MazeWalkNE where
@@ -523,7 +521,7 @@ instance IsNonEmpty (MazeWalkNE a) where
 instance NonEmptyMonad MazeWalkNE
 
 instance Magma (MazeWalkNE a) where
-  m <> t = join $ MazeWalkNE $ [m, t]
+  m <> t = join $ MazeWalkNE [m, t]
 
 instance PalindromeMagma (MazeWalkNE a)
 
@@ -563,7 +561,7 @@ newtype StutterNE (n :: Nat) a =
  deriving (Functor, Show, Eq)
 
 instance (KnownNat n) => Applicative (StutterNE n) where
-  pure a = StutterNE $ [a]  -- OverloadedLists
+  pure a = StutterNE [a]  -- OverloadedLists
   (<*>)  = ap
 
 instance (KnownNat n) => Monad (StutterNE n) where
@@ -589,7 +587,7 @@ instance (KnownNat n) => IsNonEmpty (StutterNE n a) where
 instance (KnownNat n) => NonEmptyMonad (StutterNE n)
 
 instance (KnownNat n) => Magma (StutterNE n a) where
-  m <> t = join $ StutterNE $ [m, t]
+  m <> t = join $ StutterNE [m, t]
 
 instance (KnownNat n) => StutterMagma n (StutterNE n a)
 
@@ -668,7 +666,7 @@ newtype HeadTails a = HeadTails { unHeadTails :: NonEmpty a }
  deriving (Functor, Show, Eq)
 
 instance Applicative HeadTails where
-  pure a = HeadTails $ [a,a]  -- OverloadedLists
+  pure a = HeadTails [a,a]  -- OverloadedLists
   (<*>)  = ap
 
 instance Monad HeadTails where
@@ -772,7 +770,7 @@ newtype HeadsTail a = HeadsTail { unHeadsTail :: NonEmpty a }
  deriving (Functor, Show, Eq)
 
 instance Applicative HeadsTail where
-  pure a = HeadsTail $ [a,a]  -- OverloadedLists
+  pure a = HeadsTail [a,a]  -- OverloadedLists
   (<*>)  = ap
 
 instance Monad HeadsTail where

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-16.5
+resolver: ghc-9.8.4
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -42,11 +42,22 @@ packages:
 # extra-deps: []
 
 extra-deps:
- - Cabal-3.2.0.0@sha256:d0d7a1f405f25d0000f5ddef684838bc264842304fd4e7f80ca92b997b710874,27320
- - cabal-install-parsers-0.3.0.1@sha256:c7e4c9379018f44c202b474877e5bc4089a8996e376985224e64715655dc09e1,3760
- - generic-lens-lite-0.1@sha256:ff6b891859105808b39637601c7678a434ffa18bba3d368cddd29fc3ea0474bd,1635
- - binary-instances-1.0.0.1@sha256:e234be994da675479a3661f050d4a1d53565c9ed7786d9a68b7a29ba8b54b5a7,2659
-
+           - QuickCheck-2.16.0.0@sha256:f4210647167f873196b01050ac074a44821b6687e26f792ad3474b6388c5f8b7,9208
+           - hspec-2.11.12@sha256:d16b4a90470b415d56a1b561a1735566b2d8529bdbc5b26a965785768cd26ca1,1766
+           - hspec-core-2.11.12@sha256:9862660946d84cd40142ef48b42bcc6f6769cc44ca554f7eec6f3dc695b5097b,7762
+           - hspec-discover-2.11.12@sha256:cb6b6048b6f0fa539176f4b8012241e4c518c9803eb7ef58097c42a68b15b1c3,2171
+           - HUnit-1.6.2.0@sha256:1a79174e8af616117ad39464cac9de205ca923da6582825e97c10786fda933a4,1588
+           - ansi-terminal-1.1.3@sha256:4b26711a95ec724284cdf41aaebc624d9f8a51799424f90ab09d1276bb154e7f,2760
+           - call-stack-0.4.0@sha256:ac44d2c00931dc20b01750da8c92ec443eb63a7231e8550188cb2ac2385f7feb,1200
+           - haskell-lexer-1.2.1@sha256:393300e223f7b84c334d87780481bcede98392aa8bd82bc882d76b54b7d1c699,1279
+           - hspec-expectations-0.8.4@sha256:4237f094a7931202ff57ac6475542b0b314b50a7024550e2b6eb87cfb0d4ff93,1702
+           - quickcheck-io-0.2.0@sha256:7bf0b68fb90873825eb2e5e958c1b76126dcf984debb998e81673e6d837e0b2d,1133
+           - random-1.3.1@sha256:0b4f649c3e78713b2ccad1535251ee34b148237fb2229d7058c2b1d9ccc324b8,6004
+           - splitmix-0.1.3.1@sha256:d0002f3fb16a2cc5ba8afd47a6657726386edccfe8853d310e3479fe3b45201b,6552
+           - tf-random-0.5@sha256:14012837d0f0e18fdbbe3d56e67da8622ee5e20b180abce952dd50bd9f36b326,3983
+           - ansi-terminal-types-1.1.3@sha256:1d6061eceaf35a9ed269b81177dd4c8c60403a499526f7f68fdffa4ec7842e7f,1523
+           - colour-2.3.6@sha256:ebdcbf15023958838a527e381ab3c3b1e99ed12d1b25efeb7feaa4ad8c37664a,2378
+           - primitive-0.9.1.0@sha256:dfdd6572944c11e69208237dd32a2eb9d975b4f4e9064a7b8dc952cb0e256846,3119
 
 # Override default flag values for local packages and extra-deps
 # flags: {}


### PR DESCRIPTION
Changes:

- Add `UndecidableInstances` extension to `Control.Monad.List.NonEmpty.Exotic` to deal with the `2 <= n + k` constraint in the `AlphaNOmegaK` monad on newer GHCs
- Turn off the `x-partial` warning
- Some linter suggestions